### PR TITLE
Remove Non-Functional Demo Account Section from Login Page

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -55,15 +55,6 @@ export const LoginPage: React.FC = () => {
           </p>
         </div>
 
-        {/* Demo Credentials */}
-        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-          <h3 className="font-medium text-blue-900 dark:text-blue-300 mb-2">Demo Accounts:</h3>
-          <div className="text-sm text-blue-800 dark:text-blue-400 space-y-1">
-            <div><strong>Admin:</strong> admin@pasteforge.com / password</div>
-            <div><strong>User:</strong> dev@example.com / password</div>
-          </div>
-        </div>
-
         {/* Form */}
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           <div className="space-y-4">


### PR DESCRIPTION
Removed the "Demo Accounts" box from the login page to avoid confusion, as the listed credentials are non-functional. This cleanup ensures a more accurate and professional user experience.

Deleted JSX block displaying fake credentials

Confirmed no demo accounts are referenced elsewhere

Login page UI is now clean and production-ready