### PR TITLE
Enforce Mutual Exclusivity: Disable Burn After Read When Zero-Knowledge is Enabled

### DIFF
--- a/src/pages/CreatePastePage.tsx
+++ b/src/pages/CreatePastePage.tsx
@@ -296,8 +296,10 @@ export const CreatePastePage: React.FC = () => {
   // Handle zero-knowledge toggle
   const handleZeroKnowledgeToggle = (checked: boolean) => {
     setIsZeroKnowledge(checked);
-    
+
     if (checked) {
+      // Disable burn-after-read when zero-knowledge is enabled
+      setBurnAfterRead(false);
       // Zero-knowledge pastes are automatically unlisted
       setVisibility('unlisted');
       
@@ -517,6 +519,7 @@ export const CreatePastePage: React.FC = () => {
                 type="checkbox"
                 checked={burnAfterRead}
                 onChange={(e) => handleBurnAfterReadToggle(e.target.checked)}
+                disabled={isZeroKnowledge}
                 className="h-4 w-4 text-red-600 focus:ring-red-500 border-slate-300 dark:border-slate-600 rounded"
               />
               <label htmlFor="burn-after-read" className="text-sm font-medium text-slate-700 dark:text-slate-300">


### PR DESCRIPTION
Implemented UI logic to ensure mutual exclusivity between "Zero-Knowledge Encryption" and "Burn After Read":

When "Zero-Knowledge Encryption" is checked, the "Burn After Read" checkbox is now disabled

Automatically unchecks "Burn After Read" if it was previously selected

Ensures consistent two-way behavior:

Enabling either option disables the other

Disabling one re-enables the other