### PR TITLE
Bugfix for password protected paste 

### DIFF
--- a/src/components/AI/RelatedPastes.tsx
+++ b/src/components/AI/RelatedPastes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Code, User, Tag, FileText, ArrowRight } from 'lucide-react';
+import { Code, User, Tag, FileText, ArrowRight, Lock } from 'lucide-react';
 import { RelatedPaste } from '../../types';
 
 interface RelatedPastesProps {
@@ -112,9 +112,16 @@ export const RelatedPastes: React.FC<RelatedPastesProps> = ({
                 </div>
 
                 <div className="bg-slate-50 dark:bg-slate-900 rounded p-3 mb-3">
-                  <pre className="text-xs text-slate-700 dark:text-slate-300 line-clamp-3 overflow-hidden">
-                    <code>{related.paste.content}</code>
-                  </pre>
+                  {related.paste.content === null ? (
+                    <div className="flex items-center text-slate-500 dark:text-slate-400 space-x-1">
+                      <Lock className="h-3 w-3" />
+                      <span>🔒 Password protected</span>
+                    </div>
+                  ) : (
+                    <pre className="text-xs text-slate-700 dark:text-slate-300 line-clamp-3 overflow-hidden">
+                      <code>{related.paste.content}</code>
+                    </pre>
+                  )}
                 </div>
 
                 <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">

--- a/src/components/Paste/PasteCard.tsx
+++ b/src/components/Paste/PasteCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { Eye, Star, GitFork, Code } from 'lucide-react';
+import { Eye, Star, GitFork, Code, Lock } from 'lucide-react';
 import { Paste } from '../../types';
 
 interface PasteCardProps {
@@ -51,9 +51,16 @@ export const PasteCard: React.FC<PasteCardProps> = ({ paste }) => {
         </div>
 
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg p-4 mb-4 relative overflow-hidden">
-          <pre className="text-sm text-slate-700 dark:text-slate-300 line-clamp-4 overflow-hidden">
-            <code>{paste.content}</code>
-          </pre>
+          {paste.content === null ? (
+            <div className="flex items-center text-slate-500 dark:text-slate-400 space-x-2">
+              <Lock className="h-4 w-4" />
+              <span>🔒 This paste is password protected.</span>
+            </div>
+          ) : (
+            <pre className="text-sm text-slate-700 dark:text-slate-300 line-clamp-4 overflow-hidden">
+              <code>{paste.content}</code>
+            </pre>
+          )}
           <div className="absolute inset-0 bg-gradient-to-b from-transparent to-slate-50 dark:to-slate-900 pointer-events-none"></div>
         </div>
 

--- a/src/hooks/useRelatedContent.ts
+++ b/src/hooks/useRelatedContent.ts
@@ -79,7 +79,7 @@ export const useRelatedContent = (currentPaste: Paste): UseRelatedContentReturn 
 
       // Find pastes with similar content (basic keyword matching)
       const currentWords = new Set(
-        currentPaste.content
+        (currentPaste.content || '')
           .toLowerCase()
           .replace(/[^\w\s]/g, ' ')
           .split(/\s+/)
@@ -93,7 +93,7 @@ export const useRelatedContent = (currentPaste: Paste): UseRelatedContentReturn 
         )
         .map(paste => {
           const pasteWords = new Set(
-            paste.content
+            (paste.content || '')
               .toLowerCase()
               .replace(/[^\w\s]/g, ' ')
               .split(/\s+/)

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -19,7 +19,7 @@ export const ExplorePage: React.FC = () => {
   const filteredAndSortedPastes = useMemo(() => {
     let filtered = pastes.filter(paste => {
       const matchesSearch = paste.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                           paste.content.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                           (paste.content || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
                            paste.tags.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()));
       const matchesLanguage = !selectedLanguage || paste.language === selectedLanguage;
       return matchesSearch && matchesLanguage && paste.isPublic;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -108,6 +108,7 @@ class ApiService {
       }, API_TIMEOUT);
       
       const response = await fetch(url, {
+        credentials: 'include',
         ...options,
         signal: controller.signal,
         headers: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,7 @@ export interface User {
 export interface Paste {
   id: string;
   title: string;
-  content: string;
+  content: string | null;
   language: string;
   author: User;
   createdAt: string;


### PR DESCRIPTION
Backend now hides protected paste content by selecting p.password and returning null for that paste’s content. This ensures explore endpoints do not leak protected snippets

Password verification persists the session before responding, preventing “Paste Not Found” errors after a redirect

API requests include credentials so session cookies are sent correctly

Frontend components display a lock message when content is hidden

The Paste type now allows null content to represent protected  #pastes
#21 #22 