### PR TITLE
Fix: Enable session-based access for password-protected pastes

### DIFF
--- a/server/routes/pastes.js
+++ b/server/routes/pastes.js
@@ -577,16 +577,10 @@ router.post('/:id/verify', async (req, res) => {
       return res.status(403).json({ error: 'Invalid password' });
     }
 
-    if (!req.session.verifiedPastes) req.session.verifiedPastes = [];
+    req.session.verifiedPastes = req.session.verifiedPastes || [];
     req.session.verifiedPastes.push(pasteId);
 
-    req.session.save((err) => {
-      if (err) {
-        console.error('Session save error:', err);
-        return res.status(500).json({ error: 'Failed to save session' });
-      }
-      res.json({ success: true });
-    });
+    return res.status(200).json({ success: true });
   } catch (error) {
     console.error('Password verification error:', error);
     res.status(500).json({ error: 'Failed to verify password' });


### PR DESCRIPTION
Description:
This PR resolves the issue where users are prompted for a password when accessing a protected paste but are not granted access even after entering the correct password.

Changes Made:

Added express-session middleware to enable session management.

Updated the password verification route to store verified paste IDs in the session upon successful authentication.

Modified the paste retrieval logic to respect session-based verification, allowing users to access content after entering the correct password.

Why this matters:
Without persisting the password verification status, users are stuck in a loop where they’re repeatedly prompted for a password. This fix ensures a seamless experience by storing verification state securely in the session.