### PR TITLE
Fix: Enable session cookie transmission for password-protected pastes

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -290,7 +290,8 @@ class ApiService {
   async verifyPastePassword(id: string, password: string) {
     return this.makeRequest(`${API_BASE_URL}/pastes/${id}/verify`, {
       method: 'POST',
-      body: JSON.stringify({ password })
+      body: JSON.stringify({ password }),
+      credentials: 'include'
     });
   }
 


### PR DESCRIPTION
Description:
This PR resolves the issue where users remain stuck on the password prompt even after submitting the correct password for a protected paste.

Root Cause:
The frontend did not send session cookies with the password verification request, preventing the backend from persisting session state after successful authentication.

Changes Implemented:

Added credentials: 'include' to the fetch request that verifies the paste password, ensuring session cookies are transmitted.

Confirmed that the backend CORS configuration allows credentials to be accepted (credentials: true).

Impact:
Users will now be able to successfully view password-protected pastes after entering the correct password. The session will persist their access, eliminating repeat prompts.

Testing Instructions:

Visit a password-protected paste URL.

Enter the correct password.

You should be redirected to or automatically shown the paste content.

Notes:

This requires that the session middleware and session store are already configured on the backend.

Ensure origin in CORS is correctly set to the frontend URL during deployment.

