### PR TITLE
Fix: Persist JWT token in global store for password-protected paste access

### DIFF
--- a/src/pages/PastePage.tsx
+++ b/src/pages/PastePage.tsx
@@ -97,7 +97,6 @@ export const PastePage: React.FC = () => {
   const [relatedPastes, setRelatedPastes] = useState<RelatedPaste[]>([]);
   const [passwordRequired, setPasswordRequired] = useState(false);
   const [password, setPassword] = useState('');
-  const [authToken, setAuthToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (id) {
@@ -132,7 +131,9 @@ export const PastePage: React.FC = () => {
     setError(null);
     
     try {
-      const data = await apiService.getPaste(id, authToken || undefined);
+      const { pasteAccessTokens } = useAppStore.getState();
+      const token = pasteAccessTokens[id];
+      const data = await apiService.getPaste(id, token);
       setPaste(data);
       setPasswordRequired(false);
     } catch (err) {
@@ -302,11 +303,12 @@ export const PastePage: React.FC = () => {
           <button
             onClick={async () => {
               try {
+                const { setPasteAccessToken } = useAppStore.getState();
                 const response = await apiService.verifyPastePassword(id!, password);
-                setAuthToken(response.token);
+                setPasteAccessToken(id!, response.token);
                 setPassword('');
                 setPasswordRequired(false);
-                await fetchPaste();
+                navigate(`/paste/${id}`);
               } catch (err) {
                 toast.error('Invalid password');
               }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -11,6 +11,8 @@ interface AppState {
   isLoading: boolean;
   apiError: string | null;
   backendStatus: 'unknown' | 'healthy' | 'sleeping' | 'error';
+  pasteAccessTokens: Record<string, string>;
+  setPasteAccessToken: (pasteId: string, token: string) => void;
   
   // Pastes
   loadRecentPastes: () => Promise<void>;
@@ -46,6 +48,15 @@ export const useAppStore = create<AppState>((set, get) => ({
   isLoading: false,
   apiError: null,
   backendStatus: 'unknown',
+  pasteAccessTokens: {},
+  setPasteAccessToken: (pasteId: string, token: string) => {
+    set((state) => ({
+      pasteAccessTokens: {
+        ...state.pasteAccessTokens,
+        [pasteId]: token,
+      },
+    }));
+  },
 
   loadRecentPastes: async () => {
     set({ isLoading: true, apiError: null });


### PR DESCRIPTION
Description:
This PR resolves the issue where users encounter an “Invalid token” error after being redirected to view a newly created password-protected paste.

Problem:

After a password is successfully verified, the backend returns a JWT.

The frontend immediately navigates to the paste page (/paste/:id), but does not retain or send the token.

As a result, the backend correctly rejects the request due to a missing or invalid token.

Solution:

Introduced a new global state (pasteAccessTokens) using the existing useAppStore.

The verified token is now stored in memory immediately after password verification.

On paste view, the token is automatically retrieved from the store and passed in the Authorization header.

Changes Made:

Added pasteAccessTokens map and setPasteAccessToken function to global store.

Updated password verification handler to store the JWT in memory.

Modified paste loading logic to include the token from the store.

Adjusted API service to accept an optional token for authenticated paste access.