### PR TITLE
Fix: Allow NULL values in 'content' column to support zero-knowledge pastes

### DIFF
--- a/server/database/connection.js
+++ b/server/database/connection.js
@@ -51,13 +51,13 @@ export async function initializeDatabase() {
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
     `);
-    
+
     // Create pastes table - Modified to allow NULL author_id for anonymous pastes
     await client.query(`
       CREATE TABLE IF NOT EXISTS pastes (
         id SERIAL PRIMARY KEY,
         title VARCHAR(255) NOT NULL,
-        content TEXT NOT NULL,
+        content TEXT,
         syntax_language VARCHAR(50) NOT NULL DEFAULT 'text',
         author_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
         is_private BOOLEAN DEFAULT FALSE,
@@ -71,6 +71,11 @@ export async function initializeDatabase() {
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
     `);
+
+    // Ensure content column allows NULL values for zero-knowledge pastes
+    await client.query(
+      `ALTER TABLE pastes ALTER COLUMN content DROP NOT NULL`
+    );
 
     // Ensure burn_after_read column exists for existing installations
     await client.query(


### PR DESCRIPTION
Description:
This PR updates the PostgreSQL schema to allow NULL values in the `content` column of the `pastes` table. This change is required to support zero-knowledge pastes, which store encrypted content separately and do not insert plaintext `content`.

Why This Matters:
- Prevents paste creation from failing due to `NOT NULL` constraint
- Enables correct separation between server-blind (zero-knowledge) content and regular content
- Aligns schema with application logic that already handles content/null separation

Changes:
- Executed:
```sql
ALTER TABLE pastes ALTER COLUMN content DROP NOT NULL;
```
- No changes needed to application logic — backend already passes `null` correctly when applicable

How to Test:
1. Create a new paste with "zero knowledge" option enabled
2. Submit and confirm that it creates successfully
3. Ensure non-zero-knowledge pastes still work normally

This unblocks a key privacy feature while keeping schema clean and consistent.