### PR TITLE
Fix: Hide "Save this link" banner when decryption key is missing on zero-knowledge pastes

### DIFF
--- a/src/pages/PastePage.tsx
+++ b/src/pages/PastePage.tsx
@@ -97,8 +97,23 @@ export const PastePage: React.FC = () => {
   const [relatedPastes, setRelatedPastes] = useState<RelatedPaste[]>([]);
   const [passwordRequired, setPasswordRequired] = useState(false);
   const [password, setPassword] = useState('');
+  const [hasDecryptionKey, setHasDecryptionKey] = useState(false);
 
   const { pasteAccessTokens, setPasteAccessToken } = useAppStore();
+
+  useEffect(() => {
+    setHasDecryptionKey(window.location.hash?.startsWith('#key='));
+  }, []);
+
+  useEffect(() => {
+    if (hasDecryptionKey && paste?.id) {
+      sessionStorage.setItem(`shownBannerFor-${paste.id}`, 'true');
+    }
+  }, [hasDecryptionKey, paste]);
+
+  const hasShown = paste?.id
+    ? sessionStorage.getItem(`shownBannerFor-${paste.id}`) === 'true'
+    : false;
 
   useEffect(() => {
     if (!id) return;
@@ -133,11 +148,10 @@ export const PastePage: React.FC = () => {
   }, [paste]);
 
   useEffect(() => {
-    // Show access link for zero-knowledge pastes
-    if (paste && paste.isZeroKnowledge) {
+    if (paste && paste.isZeroKnowledge && hasDecryptionKey && !hasShown) {
       setShowAccessLink(true);
     }
-  }, [paste]);
+  }, [paste, hasDecryptionKey, hasShown]);
 
   useEffect(() => {
     if (id) {
@@ -362,7 +376,7 @@ export const PastePage: React.FC = () => {
         className="space-y-8"
       >
         {/* Zero-Knowledge Access Link */}
-        {showAccessLink && paste.isZeroKnowledge && (
+        {showAccessLink && paste.isZeroKnowledge && hasDecryptionKey && !hasShown && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
Description:
Previously, users visiting a zero-knowledge paste without the `#key=` portion in the URL would still see the "Save this link" banner, even though they couldn’t decrypt the paste. This was confusing and misleading.

Changes:
- Added logic to detect whether a decryption key is present in the URL
- Only show the banner when the paste is zero-knowledge **and** the key is present
- Optional session-based flag to ensure the banner is shown only once per paste ID

Why This Matters:
- Prevents user confusion in cases where the key is missing
- Improves UX by showing accurate messaging based on context
- Maintains clean separation between view-only and creation flows

How to Test:
1. Create a zero-knowledge paste
2. Confirm the banner appears with the full link
3. Copy and open the paste URL **without the #key= portion**
4. The banner should NOT be shown, and the decryption error should be shown instead

This improves trust and usability for the zero-knowledge experience.